### PR TITLE
Add new syntax and fine-tune colors

### DIFF
--- a/Iceberg.xccolortheme
+++ b/Iceberg.xccolortheme
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>DVTConsoleDebuggerInputTextColor</key>
-	<string>0.729412 0.733333 0.780392 1</string>
+	<string>0.72813 0.735887 0.778633 1</string>
 	<key>DVTConsoleDebuggerInputTextFont</key>
 	<string>SFMono-Regular - 11.0</string>
 	<key>DVTConsoleDebuggerOutputTextColor</key>
-	<string>0.729412 0.733333 0.780392 1</string>
+	<string>0.72813 0.735887 0.778633 1</string>
 	<key>DVTConsoleDebuggerOutputTextFont</key>
 	<string>SFMono-Regular - 11.0</string>
 	<key>DVTConsoleDebuggerPromptTextColor</key>
@@ -15,21 +15,21 @@
 	<key>DVTConsoleDebuggerPromptTextFont</key>
 	<string>SFMono-Regular - 11.0</string>
 	<key>DVTConsoleExectuableInputTextColor</key>
-	<string>0.729412 0.733333 0.780392 1</string>
+	<string>0.72813 0.735887 0.778633 1</string>
 	<key>DVTConsoleExectuableInputTextFont</key>
 	<string>SFMono-Regular - 11.0</string>
 	<key>DVTConsoleExectuableOutputTextColor</key>
-	<string>0.729412 0.733333 0.780392 1</string>
+	<string>0.72813 0.735887 0.778633 1</string>
 	<key>DVTConsoleExectuableOutputTextFont</key>
 	<string>SFMono-Regular - 11.0</string>
 	<key>DVTConsoleTextBackgroundColor</key>
-	<string>0.0666667 0.0705882 0.0980392 1</string>
+	<string>0.0685795 0.0727915 0.0976576 1</string>
 	<key>DVTConsoleTextInsertionPointColor</key>
-	<string>0.729412 0.733333 0.780392 1</string>
+	<string>0.72813 0.735887 0.778633 1</string>
 	<key>DVTConsoleTextSelectionColor</key>
-	<string>0.113725 0.12549 0.196078 1</string>
-	<key>DVTDebuggerInstructionPointerColor</key>
-	<string>0.647059 0.698039 0.435294 1</string>
+	<string>0.114894 0.126748 0.19836 1</string>
+	<key>DVTFontAndColorVersion</key>
+	<integer>1</integer>
 	<key>DVTLineSpacing</key>
 	<real>1.1000000238418579</real>
 	<key>DVTMarkupTextBackgroundColor</key>
@@ -59,7 +59,7 @@
 	<key>DVTMarkupTextPrimaryHeadingColor</key>
 	<string>0 0 0 1</string>
 	<key>DVTMarkupTextPrimaryHeadingFont</key>
-	<string>.SFNSDisplay - 24.0</string>
+	<string>.SFNS-Regular - 24.0</string>
 	<key>DVTMarkupTextSecondaryHeadingColor</key>
 	<string>0 0 0 1</string>
 	<key>DVTMarkupTextSecondaryHeadingFont</key>
@@ -68,8 +68,22 @@
 	<string>0 0 0 1</string>
 	<key>DVTMarkupTextStrongFont</key>
 	<string>.AppleSystemUIFontBold - 10.0</string>
+	<key>DVTScrollbarMarkerAnalyzerColor</key>
+	<string>0.403922 0.372549 1 1</string>
+	<key>DVTScrollbarMarkerBreakpointColor</key>
+	<string>0.290196 0.290196 0.968627 1</string>
+	<key>DVTScrollbarMarkerDiffColor</key>
+	<string>0.556863 0.556863 0.556863 1</string>
+	<key>DVTScrollbarMarkerDiffConflictColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerErrorColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerRuntimeIssueColor</key>
+	<string>0.643137 0.509804 1 1</string>
+	<key>DVTScrollbarMarkerWarningColor</key>
+	<string>0.937255 0.717647 0.34902 1</string>
 	<key>DVTSourceTextBackground</key>
-	<string>0.06858 0.0727896 0.0976567 1</string>
+	<string>0.0685795 0.0727915 0.0976576 1</string>
 	<key>DVTSourceTextBlockDimBackgroundColor</key>
 	<string>0.5 0.5 0.5 1</string>
 	<key>DVTSourceTextCurrentLineHighlightColor</key>
@@ -79,7 +93,7 @@
 	<key>DVTSourceTextInvisiblesColor</key>
 	<string>0.106307 0.117749 0.191766 1</string>
 	<key>DVTSourceTextSelectionColor</key>
-	<string>0.114895 0.126744 0.198358 1</string>
+	<string>0.114894 0.126748 0.19836 1</string>
 	<key>DVTSourceTextSyntaxColors</key>
 	<dict>
 		<key>xcode.syntax.attribute</key>
@@ -91,7 +105,11 @@
 		<key>xcode.syntax.comment.doc</key>
 		<string>0.344948 0.360409 0.462776 1</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>0.648429 0.699864 0.435616 1</string>
+		<string>0.648426 0.699881 0.435619 1</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.445512 0.55512 0.72735 1</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.445512 0.55512 0.72735 1</string>
 		<key>xcode.syntax.identifier.class</key>
 		<string>0.445517 0.555106 0.727344 1</string>
 		<key>xcode.syntax.identifier.class.system</key>
@@ -113,11 +131,15 @@
 		<key>xcode.syntax.identifier.type.system</key>
 		<string>0.648429 0.699864 0.435616 1</string>
 		<key>xcode.syntax.identifier.variable</key>
-		<string>0.728133 0.735868 0.778626 1</string>
+		<string>0.72813 0.735887 0.778633 1</string>
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>0.728133 0.735868 0.778626 1</string>
 		<key>xcode.syntax.keyword</key>
-		<string>0.445517 0.555106 0.727344 1</string>
+		<string>0.445512 0.55512 0.72735 1</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.648426 0.699881 0.435619 1</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>0.445512 0.55512 0.72735 1</string>
 		<key>xcode.syntax.number</key>
 		<string>0.557586 0.493999 0.731992 1</string>
 		<key>xcode.syntax.plain</key>
@@ -141,6 +163,10 @@
 		<string>SFMono-Regular - 11.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
 		<string>SFMono-Regular - 11.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>SFMono-Regular - 11.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>SFMono-Regular - 11.0</string>
 		<key>xcode.syntax.identifier.class</key>
 		<string>SFMono-Regular - 11.0</string>
 		<key>xcode.syntax.identifier.class.system</key>
@@ -166,6 +192,10 @@
 		<key>xcode.syntax.identifier.variable.system</key>
 		<string>SFMono-Regular - 11.0</string>
 		<key>xcode.syntax.keyword</key>
+		<string>SFMono-Regular - 11.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>SFMono-Regular - 11.0</string>
+		<key>xcode.syntax.markup.code</key>
 		<string>SFMono-Regular - 11.0</string>
 		<key>xcode.syntax.number</key>
 		<string>SFMono-Regular - 11.0</string>


### PR DESCRIPTION
The current Xcode theme had some colors that were slightly different from Iceberg's original colors, so these were corrected.

|Before|After|
|---|---|
|![](https://user-images.githubusercontent.com/54178415/184732744-1323ce4b-dd33-4dab-bea0-af7bf7d57638.png)|![](https://user-images.githubusercontent.com/54178415/184732784-549700dc-5bec-4b79-904b-e3c91fbdc7d6.png)|
<br>

And also, the currently unset

- Marks
- Type Declarations
- Other Declarations
- Heading

Color and font settings have been added for these four syntaxes, which are not currently set.

|Before|After|
|---|---|
|![](https://user-images.githubusercontent.com/54178415/184733680-7eea44bb-a9fe-453d-873e-099508d9acf2.png)|![](https://user-images.githubusercontent.com/54178415/184733693-c79046c1-7f54-4737-9ef8-3c0c0e5dc668.png)|
